### PR TITLE
Fix for patch 8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+** Version 1.2.2 **
+* Enabled auto-invite for +5 groups again. // spam bug seems fixed.
+
 ** Version 1.2.1 **
 * Disabled auto-invite for 5+ groups. Till fixed found for RaidConvert spaming.
 * sorry for that =(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+** Version 1.2.1 **
+* Disabled auto-invite for 5+ groups. Till fixed found for RaidConvert spaming.
+* sorry for that =(
+
 ** Version 1.2 **
 * Updated toc.
 * BugFixed: double invite people from list.
-
 
 ** Version 1.1 **
 * Cleaned up implementation to no longer rely on hacky code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+** Version 1.2 **
+* Updated toc.
+* BugFixed: double invite people from list.
+
+
 ** Version 1.1 **
 * Cleaned up implementation to no longer rely on hacky code.
 * Added role-specific auto-inviting, since we're at it.

--- a/PremadeAutoAccept.lua
+++ b/PremadeAutoAccept.lua
@@ -1,7 +1,7 @@
 --[[
 	PremadeAutoAccept (C) Kruithne <kruithne@gmail.com>
 	Licensed under GNU General Public Licence version 3.
-	
+
 	https://github.com/Kruithne/PremadeAutoAccept
 ]]--
 
@@ -13,17 +13,18 @@ local autoAccepting = {};
 local function InviteApplicants()
 	local applicants = C_LFGList.GetApplicants();
 	for i = 1, #applicants do
-		local id, status, pendingStatus, numMembers = C_LFGList.GetApplicantInfo(applicants[i]);
+		local applicantData = C_LFGList.GetApplicantInfo(applicants[i]);
 
 		-- Using the premade "invite" feature does not work, as Blizzard have broken auto-accept intentionally
 		-- Because of this, we can't invite groups, but we can still send normal invites to singletons.
-		if numMembers == 1 and (pendingStatus or status == "applied") then
-			local name, _, _, _, _, _, _, _, _, assignedRole  = C_LFGList.GetApplicantMemberInfo(id, 1);
+		if applicantData and (applicantData.applicationStatus or applicantData.pendingApplicationStatus == "applied") and applicantData.numMembers == 1 then
+
+			local name, _, _, _, _, _, _, _, _, assignedRole  = C_LFGList.GetApplicantMemberInfo(applicants[i], 1);
 			if autoAccepting[assignedRole] then
 				InviteUnit(name);
 			end
 		end
-	end
+	endwd
 end
 
 local function OnCheckBoxClick(self)

--- a/PremadeAutoAccept.lua
+++ b/PremadeAutoAccept.lua
@@ -77,6 +77,9 @@ local function CreateAutoAcceptButtons()
 
 	local tankButton = CreateCheckbox("groupfinder-icon-role-large-tank", "TANK");
 	tankButton:SetPoint("LEFT", healerButton.icon, "RIGHT", 5, 0);
+
+--[[ 	local allButton = CreateCheckbox("groupfinder-icon-quest", "ALL");
+	allButton:SetPoint("LEFT", tankButton.icon, "RIGHT", 5, 0); ]]
 end
 
 local function OnLoad()
@@ -94,6 +97,7 @@ local function OnApplicantListUpdated()
 			if not displayedRaidConvert and not IsInRaid(LE_PARTY_CATEGORY_HOME) then
 				local futureCount = GetNumGroupMembers(LE_PARTY_CATEGORY_HOME) + C_LFGList.GetNumInvitedApplicantMembers() + C_LFGList.GetNumPendingApplicantMembers();
 				if futureCount > (MAX_PARTY_MEMBERS + 1) then
+					do return end;
 					StaticPopup_Show("LFG_LIST_AUTO_ACCEPT_CONVERT_TO_RAID");
 					displayedRaidConvert = true;
 				end

--- a/PremadeAutoAccept.lua
+++ b/PremadeAutoAccept.lua
@@ -17,7 +17,7 @@ local function InviteApplicants()
 
 		-- Using the premade "invite" feature does not work, as Blizzard have broken auto-accept intentionally
 		-- Because of this, we can't invite groups, but we can still send normal invites to singletons.
-		if applicantData and (applicantData.applicationStatus or applicantData.pendingApplicationStatus == "applied") and applicantData.numMembers == 1 then
+		if applicantData and (applicantData.applicationStatus == "applied" or applicantData.pendingApplicationStatus == "applied") and applicantData.numMembers == 1 then
 
 			local name, _, _, _, _, _, _, _, _, assignedRole  = C_LFGList.GetApplicantMemberInfo(applicants[i], 1);
 			if autoAccepting[assignedRole] then

--- a/PremadeAutoAccept.lua
+++ b/PremadeAutoAccept.lua
@@ -24,7 +24,7 @@ local function InviteApplicants()
 				InviteUnit(name);
 			end
 		end
-	endwd
+	end
 end
 
 local function OnCheckBoxClick(self)

--- a/PremadeAutoAccept.lua
+++ b/PremadeAutoAccept.lua
@@ -77,9 +77,6 @@ local function CreateAutoAcceptButtons()
 
 	local tankButton = CreateCheckbox("groupfinder-icon-role-large-tank", "TANK");
 	tankButton:SetPoint("LEFT", healerButton.icon, "RIGHT", 5, 0);
-
---[[ 	local allButton = CreateCheckbox("groupfinder-icon-quest", "ALL");
-	allButton:SetPoint("LEFT", tankButton.icon, "RIGHT", 5, 0); ]]
 end
 
 local function OnLoad()
@@ -97,12 +94,19 @@ local function OnApplicantListUpdated()
 			if not displayedRaidConvert and not IsInRaid(LE_PARTY_CATEGORY_HOME) then
 				local futureCount = GetNumGroupMembers(LE_PARTY_CATEGORY_HOME) + C_LFGList.GetNumInvitedApplicantMembers() + C_LFGList.GetNumPendingApplicantMembers();
 				if futureCount > (MAX_PARTY_MEMBERS + 1) then
-					do return end;
 					StaticPopup_Show("LFG_LIST_AUTO_ACCEPT_CONVERT_TO_RAID");
 					displayedRaidConvert = true;
 				end
 			end
-
+			-- tried to fix the raid convert spam bug
+			if displayedRaidConvert and not IsInRaid(LE_PARTY_CATEGORY_HOME) then
+				if futureCount < (MAX_PARTY_MEMBERS + 1) then
+					InviteApplicants();
+					do return end;
+				else
+					do return end;
+				end 
+			end
 			InviteApplicants();
 		end
 	end

--- a/PremadeAutoAccept.toc
+++ b/PremadeAutoAccept.toc
@@ -1,8 +1,8 @@
 ## Interface: 80300
-## Title: PremadeAutoAccept for Party's
+## Title: PremadeAutoAccept
 ## Notes: Returns the auto-accept button to the premade group finder
-## Author: Kruithne Fixed by: Lonermax
-## Version: 1.0.2.1
+## Author: Kruithne
+## Version: 1.2.2
 
 ## X-Curse-Project-ID: premade-auto-accept
 ## X-GitHub-Repo: Kruithne/PremadeAutoAccept

--- a/PremadeAutoAccept.toc
+++ b/PremadeAutoAccept.toc
@@ -1,8 +1,8 @@
-## Interface: 80000
+## Interface: 80300
 ## Title: PremadeAutoAccept
 ## Notes: Returns the auto-accept button to the premade group finder
-## Author: Kruithne
-## Version: 1.0.1
+## Author: Kruithne Fixed by: Lonermax
+## Version: 1.0.2
 
 ## X-Curse-Project-ID: premade-auto-accept
 ## X-GitHub-Repo: Kruithne/PremadeAutoAccept

--- a/PremadeAutoAccept.toc
+++ b/PremadeAutoAccept.toc
@@ -1,8 +1,8 @@
 ## Interface: 80300
-## Title: PremadeAutoAccept
+## Title: PremadeAutoAccept for Party's
 ## Notes: Returns the auto-accept button to the premade group finder
 ## Author: Kruithne Fixed by: Lonermax
-## Version: 1.0.2
+## Version: 1.0.2.1
 
 ## X-Curse-Project-ID: premade-auto-accept
 ## X-GitHub-Repo: Kruithne/PremadeAutoAccept


### PR DESCRIPTION
Hi,

first of all **thanks you** for creating this awesome addon.
i fixed it a while ago for me & friends. #3 

Beware it has/had a bug. (hopefully fixed with last version) 

The group to raid convert keeps popping up, because it didn't checked if you want stay in group (5 ppl.) but keep's inviting players which _triggered another group to raid popup._


Would be nice if you could review it.

best regards
