### PR TITLE
fixed "attempt to compare nil with number" error

### DIFF
--- a/PremadeAutoAccept.lua
+++ b/PremadeAutoAccept.lua
@@ -88,18 +88,16 @@ local function OnLoad()
 end
 
 local function OnApplicantListUpdated()
-	if UnitIsGroupLeader("player", LE_PARTY_CATEGORY_HOME) then
-		if isAutoAccepting then
+	if isAutoAccepting and UnitIsGroupLeader("player", LE_PARTY_CATEGORY_HOME) then
+		if not IsInRaid(LE_PARTY_CATEGORY_HOME) then
+			local futureCount = GetNumGroupMembers(LE_PARTY_CATEGORY_HOME) + C_LFGList.GetNumInvitedApplicantMembers() + C_LFGList.GetNumPendingApplicantMembers();
 			-- Display conversion to raid notice.
-			if not displayedRaidConvert and not IsInRaid(LE_PARTY_CATEGORY_HOME) then
-				local futureCount = GetNumGroupMembers(LE_PARTY_CATEGORY_HOME) + C_LFGList.GetNumInvitedApplicantMembers() + C_LFGList.GetNumPendingApplicantMembers();
-				if futureCount > (MAX_PARTY_MEMBERS + 1) then
-					StaticPopup_Show("LFG_LIST_AUTO_ACCEPT_CONVERT_TO_RAID");
-					displayedRaidConvert = true;
-				end
+			if not displayedRaidConvert and futureCount > (MAX_PARTY_MEMBERS + 1) then
+				StaticPopup_Show("LFG_LIST_AUTO_ACCEPT_CONVERT_TO_RAID");
+				displayedRaidConvert = true;
 			end
 			-- tried to fix the raid convert spam bug
-			if displayedRaidConvert and not IsInRaid(LE_PARTY_CATEGORY_HOME) then
+			if displayedRaidConvert then
 				if futureCount < (MAX_PARTY_MEMBERS + 1) then
 					InviteApplicants();
 					do return end;
@@ -107,8 +105,8 @@ local function OnApplicantListUpdated()
 					do return end;
 				end 
 			end
-			InviteApplicants();
 		end
+		InviteApplicants();
 	end
 end
 

--- a/PremadeAutoAccept.lua
+++ b/PremadeAutoAccept.lua
@@ -100,10 +100,8 @@ local function OnApplicantListUpdated()
 			if displayedRaidConvert then
 				if futureCount < (MAX_PARTY_MEMBERS + 1) then
 					InviteApplicants();
-					do return end;
-				else
-					do return end;
 				end 
+				do return end;
 			end
 		end
 		InviteApplicants();
@@ -122,7 +120,6 @@ local function OnEvent(self, event, ...)
 	elseif event == "LFG_LIST_APPLICANT_LIST_UPDATED" or event == "PARTY_LEADER_CHANGED" then
 		OnApplicantListUpdated();
 	elseif event == "GROUP_LEFT" then
-		isAutoAccepting = false;
 		displayedRaidConvert = false;
 	end
 end


### PR DESCRIPTION
* fixed "PremadeAutoAccept-1.2.2.lua:103: attempt to compare nil with number" error which occurred due to accessing nonexistent "futureCount" global variable instead of the local one.
* fixed isAutoAccepting to no longer be reset on group change, since the checkboxes remained check.
This has previously led to confusion of addon not working after changing the group if someone hasn't re-ticked the checkboxes.